### PR TITLE
Update miner.h

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -10,6 +10,16 @@
 #include <jansson.h>
 #include <curl/curl.h>
 
+#ifndef  MAP_ANONYMOUS
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#ifndef MAP_HUGETLB
+#define MAP_HUGETLB 0
+#endif
+#ifndef MAP_POPULATE 
+#define MAP_POPULATE 0 
+#endif 
+
 #ifdef STDC_HEADERS
 # include <stdlib.h>
 # include <stddef.h>


### PR DESCRIPTION
fixes compiler errors on OS X 10.9
